### PR TITLE
Update action.yaml

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -90,8 +90,8 @@ runs:
         printf "I'm gonna check %s for a status...\n" "${statusLocation}"
         while (( counter < numberOfSteps )) && [[ -z "${target_url}" ]]; do
             sleep ${{ inputs.delay-in-seconds }}
-        
-            target_url=$(gh api "${statusLocation}" | jq -r '.[] | select(.context | (contains("platformsh") or contains("upsun"))) | select(.state | contains("success")) | .target_url' )
+            
+            target_url=$(gh api "${statusLocation}" | jq -r '[.[] | select(.context | (contains("platformsh") or contains("upsun"))) | select(.state | contains("success")) | .target_url][0]' | tr -d '\n\r')
             printf "Attempt %d of %d.\n" "${counter}" "${numberOfSteps}"
             counter=$((++counter))
         done


### PR DESCRIPTION
seems that we receive the url twice: 

Logs from my [PR](https://github.com/upsun/devcenter/actions/runs/17040938491/job/48313068249)
```
Notice: Environment https://pr-212-y2qsekq-5c2jjy3p7slv6.ca-1.platformsh.site/
https://pr-212-y2qsekq-5c2jjy3p7slv6.ca-1.platformsh.site/ deployed!
```
but it should be: 
```
Notice: Environment https://pr-212-y2qsekq-5c2jjy3p7slv6.ca-1.platformsh.site/ deployed!
```

(and Claude.ai suggested this correction :P )